### PR TITLE
ENH: enable vertical / tree layout

### DIFF
--- a/qtpynodeeditor/connection.py
+++ b/qtpynodeeditor/connection.py
@@ -80,7 +80,7 @@ class Connection(QObject, Serializable):
         for port_type, port in self.valid_ports.items():
             if port.node.graphics_object is not None:
                 port.node.graphics_object.update()
-            self._ports[port] = None
+            self._ports[port_type] = None
 
         if self._graphics_object is not None:
             self._graphics_object._cleanup()

--- a/qtpynodeeditor/connection.py
+++ b/qtpynodeeditor/connection.py
@@ -49,7 +49,7 @@ class Connection(QObject, Serializable):
         if in_port is not None:
             if in_port.connections:
                 conn, = in_port.connections
-                existing_in, existing_out = conn.ports
+                existing_out, existing_in = conn.ports
                 if existing_in == in_port and existing_out == out_port:
                     raise exceptions.PortsAlreadyConnectedError(
                         'Specified ports already connected')
@@ -98,7 +98,7 @@ class Connection(QObject, Serializable):
         -------
         value : dict
         """
-        in_port, out_port = self.ports
+        out_port, in_port = self.ports
         if not in_port and not out_port:
             return {}
 
@@ -248,12 +248,12 @@ class Connection(QObject, Serializable):
     @property
     def nodes(self):
         # TODO namedtuple; TODO order
-        return (self.get_node(PortType.input), self.get_node(PortType.output))
+        return (self.get_node(PortType.output), self.get_node(PortType.input))
 
     @property
     def ports(self):
         # TODO namedtuple; TODO order
-        return (self._ports[PortType.input], self._ports[PortType.output])
+        return (self._ports[PortType.output], self._ports[PortType.input])
 
     def get_port_index(self, port_type: PortType) -> int:
         """
@@ -347,7 +347,7 @@ class Connection(QObject, Serializable):
         ----------
         node_data : NodeData
         """
-        in_port, out_port = self.ports
+        out_port, in_port = self.ports
         if not in_port:
             return
 

--- a/qtpynodeeditor/connection_geometry.py
+++ b/qtpynodeeditor/connection_geometry.py
@@ -12,6 +12,7 @@ class ConnectionGeometry:
         self._line_width = 3.0
         self._hovered = False
         self._point_diameter = style.connection.point_diameter
+        self._spline_type = style.connection.spline_type
 
     def get_end_point(self, port_type: PortType) -> QPointF:
         """

--- a/qtpynodeeditor/examples/calculator.py
+++ b/qtpynodeeditor/examples/calculator.py
@@ -270,7 +270,7 @@ class NumberSourceDataModel(NodeDataModel):
         try:
             number = float(self._line_edit.text())
         except ValueError:
-            self._data_invalidated.emit(0)
+            self.data_invalidated.emit(0)
         else:
             self._number = DecimalData(number)
             self.data_updated.emit(0)

--- a/qtpynodeeditor/examples/tree.py
+++ b/qtpynodeeditor/examples/tree.py
@@ -5,7 +5,7 @@ from qtpy.QtWidgets import QApplication
 import qtpynodeeditor as nodeeditor
 from qtpynodeeditor import (Connection, NodeData, NodeDataModel, NodeDataType,
                             NodeValidationState, Port, PortType)
-from qtpynodeeditor.style import LayoutDirection, StyleCollection
+from qtpynodeeditor.style import LayoutDirection, SplineType, StyleCollection
 
 
 class BlankNodeData(NodeData):
@@ -184,6 +184,7 @@ def main(app):
 
     my_style = StyleCollection()
     my_style.node.layout_direction = LayoutDirection.VERTICAL
+    my_style.connection.spline_type = SplineType.LINEAR
 
     models = (LeafNodeModel, MultiChildNodeModel, RootNodeModel,)
 

--- a/qtpynodeeditor/examples/tree.py
+++ b/qtpynodeeditor/examples/tree.py
@@ -1,0 +1,234 @@
+import logging
+
+from qtpy.QtWidgets import QApplication
+
+import qtpynodeeditor as nodeeditor
+from qtpynodeeditor import (Connection, NodeData, NodeDataModel, NodeDataType,
+                            NodeValidationState, Port, PortType)
+from qtpynodeeditor.style import LayoutDirection, StyleCollection
+
+
+class BlankNodeData(NodeData):
+    """
+    Node data with no caption.  We don't actually pass data between nodes,
+    so there's no need to label the ports
+    """
+    # port caption defaults to node data type if there's no caption provided
+    # add some spaces to help with spacing
+    data_type = NodeDataType("n/a", "  ")
+
+
+class RootNodeModel(NodeDataModel):
+    """
+    Root node model.  Simply holds one child
+    Is valid if it has a child
+    """
+    caption_visible = True
+    num_ports = {"input": 0, "output": 1}
+    port_caption_visible = {
+        "input": {},
+        "output": {0: False},
+    }
+    data_type = BlankNodeData.data_type
+    name = "Root"
+
+    def set_out_data(self, node_data: BlankNodeData, port: Port):
+        # only validating that the output node exists
+        # self._parent_node = node_data.parent_node
+        try:
+            self._child_node = port.connections[0].output_node
+            self._validation_state = NodeValidationState.valid
+            self._validation_message = "Connected"
+        except IndexError:
+            self._validation_state = NodeValidationState.warning
+            self._validation_message = "Uninitialized"
+
+
+class MultiChildNodeModel(NodeDataModel):
+    """
+    Mixin class holding logic to enable dynamic number of children.
+    This requires making .num_ports, .data_type, and .port_caption_visible
+    react to the number of connections.
+
+    num_ports is a property to avoid the validation performed by NodeDataModel
+
+    Takes a variable number of children, and is valid if it has a parent
+    """
+    def __init__(self, style=None, parent=None, max_children: int = 0):
+        super().__init__(style=style, parent=parent)
+        self.caption_visible = True
+        self.max_children = max_children
+        # initial ports
+        self._num_ports = {"input": 1, "output": 1}
+        self._port_caption_visible = {
+            "input": {0: False},
+            "output": {0: False},
+        }
+        # for multiple ouptuts, must provide a dictionary
+        # NodeDataModel tries to fill sensible default dictionaries, but gives up
+        # if num_ports is a property (if dynamically defined)
+        self._data_type = {
+            "input": {0: BlankNodeData.data_type},
+            "output": {0: BlankNodeData.data_type},
+        }
+
+        self._parent_node = None
+        self._validation_state = NodeValidationState.warning
+        self._validation_message = "Uninitialized"
+
+        self.output_connections = []
+
+    def validation_state(self) -> NodeValidationState:
+        return self._validation_state
+
+    def validation_message(self) -> str:
+        return self._validation_message
+
+    def set_in_data(self, node_data: BlankNodeData, port: Port):
+        # only validating that the parent node is a valid predecessor
+        # self._parent_node = node_data.parent_node
+        try:
+            self._parent_node = port.connections[0].input_node
+            self._validation_state = NodeValidationState.valid
+            self._validation_message = "Connected"
+        except IndexError:
+            self._validation_state = NodeValidationState.warning
+            self._validation_message = "Uninitialized"
+
+    @property
+    def num_ports(self):
+        return self._num_ports
+
+    @property
+    def data_type(self):
+        return self._data_type
+
+    @property
+    def port_caption_visible(self):
+        return self._port_caption_visible
+
+    def output_connection_created(self, connection: Connection):
+        if connection in self.output_connections:
+            return
+        self.output_connections.append(connection)
+        self._update_output_info()
+
+    def output_connection_deleted(self, connection):
+        if connection not in self.output_connections:
+            return
+        self.output_connections.remove(connection)
+        self._update_output_info()
+
+    def _update_output_info(self):
+        if self.max_children > 0:
+            num_new_conn = min(len(self.output_connections) + 1,
+                               self.max_children)
+        else:
+            num_new_conn = len(self.output_connections) + 1
+
+        self._num_ports["output"] = num_new_conn
+        self._port_caption_visible["output"] = {
+            i: False for i in range(num_new_conn)
+        }
+        self._data_type["output"] = {
+            i: BlankNodeData.data_type for i in range(num_new_conn)
+        }
+
+
+class LeafNodeModel(NodeDataModel):
+    """
+    NodeModel mixin for leaf nodes (action nodes)
+    Takes no children, and is valid if it has a parent
+    """
+    caption_visible = True
+    num_ports = {"input": 1, "output": 0}
+    port_caption_visible = {
+        "input": {0: False},
+        "output": {}
+    }
+    data_type = BlankNodeData.data_type
+
+    def __init__(self, style=None, parent=None):
+        super().__init__(style=style, parent=parent)
+        self._parent_node = None
+        self._validation_state = NodeValidationState.warning
+        self._validation_message = "Uninitialized"
+
+    def __init_subclass__(cls, verify=True, **kwargs):
+        return super().__init_subclass__(verify, **kwargs)
+
+    @property
+    def caption(self):
+        return self.name
+
+    def set_in_data(self, node_data: BlankNodeData, port: Port):
+        # only validating that the parent node is a valid predecessor
+        # self._parent_node = node_data.parent_node
+        try:
+            self._parent_node = port.connections[0].input_node
+            self._validation_state = NodeValidationState.valid
+            self._validation_message = "Connected"
+        except IndexError:
+            self._validation_state = NodeValidationState.warning
+            self._validation_message = "Uninitialized"
+
+    def validation_state(self) -> NodeValidationState:
+        return self._validation_state
+
+    def validation_message(self) -> str:
+        return self._validation_message
+
+
+def main(app):
+    registry = nodeeditor.DataModelRegistry()
+
+    my_style = StyleCollection()
+    my_style.node.layout_direction = LayoutDirection.VERTICAL
+
+    models = (LeafNodeModel, MultiChildNodeModel, RootNodeModel,)
+
+    for model in models:
+        registry.register_model(model, category='Nodes',
+                                style=my_style)
+
+    scene = nodeeditor.FlowScene(style=my_style, registry=registry)
+
+    view = nodeeditor.FlowView(scene)
+    view.setWindowTitle("Tree example")
+    view.resize(800, 600)
+    view.show()
+
+    root = scene.create_node(RootNodeModel)
+    parent_1 = scene.create_node(MultiChildNodeModel)
+    parent_2 = scene.create_node(MultiChildNodeModel)
+    parent_3 = scene.create_node(MultiChildNodeModel)
+    parent_3.model.name = "parent"
+    leaf_1 = scene.create_node(LeafNodeModel)
+    leaf_1.model.name = "action"
+    leaf_2 = scene.create_node(LeafNodeModel)
+
+    scene.create_connection(root[PortType.output][0],
+                            parent_1[PortType.input][0])
+    scene.create_connection(parent_1[PortType.output][0],
+                            parent_2[PortType.input][0])
+    scene.create_connection(parent_1[PortType.output][1],
+                            parent_3[PortType.input][0])
+    scene.create_connection(parent_3[PortType.output][0],
+                            leaf_1[PortType.input][0])
+    scene.create_connection(parent_3[PortType.output][1],
+                            leaf_2[PortType.input][0])
+
+    try:
+        scene.auto_arrange(layout="pygraphviz", prog="dot")
+    except ImportError:
+        ...
+
+    return scene, view
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level="DEBUG")
+    app = QApplication([])
+    scene, view = main(app)
+    view.show()
+    app.exec_()

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -213,7 +213,7 @@ class FlowSceneModel:
         ----------
         conn : Connection
         """
-        input_node, output_node = conn.nodes
+        output_node, input_node = conn.nodes
         assert input_node is not None
         assert output_node is not None
         output_node.model.output_connection_created(conn)
@@ -227,7 +227,7 @@ class FlowSceneModel:
         ----------
         conn : Connection
         """
-        input_node, output_node = conn.nodes
+        output_node, input_node = conn.nodes
         assert input_node is not None
         assert output_node is not None
         output_node.model.output_connection_deleted(conn)
@@ -537,7 +537,7 @@ class FlowScene(FlowSceneModel, QGraphicsScene):
         self._connections.append(connection)
 
         if port_a and port_b:
-            in_port, out_port = connection.ports
+            out_port, in_port = connection.ports
             out_port.node.on_data_updated(out_port)
             self.connection_created.emit(connection)
 

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -666,14 +666,31 @@ class FlowScene(FlowSceneModel, QGraphicsScene):
             for name in ('bipartite', 'circular', 'kamada_kawai', 'random',
                          'shell', 'spring', 'spectral')
         }
+        layouts["pygraphviz"] = networkx.nx_agraph.pygraphviz_layout
 
         try:
             layout_func = layouts[layout]
         except KeyError:
             raise ValueError(f'Unknown layout type {layout}') from None
 
-        layout = layout_func(dig, **kwargs)
-        for node, pos in layout.items():
+        # pygraphviz layouts seem to take node labels into account for spacing
+        # (in our case this is the the long repr)
+        if layout == "pygraphviz":
+            int_to_node = {i: node for i, node in enumerate(dig.nodes)}
+            node_to_int = {node: i for i, node in int_to_node.items()}
+            dig = networkx.relabel_nodes(dig, node_to_int)
+
+        layout_data = layout_func(dig, **kwargs)
+        # some layouts are not unit vector scaled
+        layout_data = networkx.rescale_layout_dict(layout_data)
+
+        if layout == "pygraphviz":
+            # undo int mapping, flip y orientation
+            dig = networkx.relabel_nodes(dig, int_to_node)
+            layout_data = {int_to_node[node_label]: (pos_x, -pos_y)
+                           for node_label, (pos_x, pos_y) in layout_data.items()}
+
+        for node, pos in layout_data.items():
             pos_x, pos_y = pos
             node.position = (pos_x * scale, pos_y * scale)
 

--- a/qtpynodeeditor/node_connection_interaction.py
+++ b/qtpynodeeditor/node_connection_interaction.py
@@ -170,7 +170,7 @@ class NodeConnectionInteraction:
         self._node.graphics_object.move_connections()
 
         # 5) Poke model to intiate data transfer
-        _, out_port = self._connection.ports
+        out_port, in_port = self._connection.ports
         if out_port:
             out_port.node.on_data_updated(out_port)
 

--- a/qtpynodeeditor/node_geometry.py
+++ b/qtpynodeeditor/node_geometry.py
@@ -240,7 +240,7 @@ class NodeGeometry:
         port_type: PortType,
         index: int
     ) -> typing.Tuple[float, float]:
-        
+
         step = self._entry_height + self._spacing
         total_height = float(self.caption_height) + step * index
         # TODO_UPSTREAM: why?
@@ -259,7 +259,7 @@ class NodeGeometry:
         port_type: PortType,
         index: int
     ) -> typing.Tuple[float, float]:
-        
+
         step = self._entry_height + self._spacing
         # TODO: see if we can set up centered nodes
         total_width = step * index

--- a/qtpynodeeditor/node_geometry.py
+++ b/qtpynodeeditor/node_geometry.py
@@ -234,6 +234,9 @@ class NodeGeometry:
             height = max((height, widget.height()))
         height += self.caption_height
 
+        if self._node.style.layout_direction == LayoutDirection.VERTICAL:
+            height += self.caption_height  # Some more padding for portnames
+
         if widget:
             width += widget.width()
         width = max((width, self.caption_width))

--- a/qtpynodeeditor/node_geometry.py
+++ b/qtpynodeeditor/node_geometry.py
@@ -269,18 +269,15 @@ class NodeGeometry:
         port_type: PortType,
         index: int
     ) -> typing.Tuple[float, float]:
-
-        step = self._entry_height + self._spacing
-        # TODO: see if we can set up centered nodes
-        total_width = step * index
-        total_width += step / 2.0
+        total_num_ports = self._model.num_ports[port_type]
+        x = self._width / (total_num_ports + 1) * (index + 1)
         if port_type == PortType.output:
             y = self._height + self._style.connection_point_diameter
         elif port_type == PortType.input:
             y = -float(self._style.connection_point_diameter)
         else:
             raise ValueError(port_type)
-        return total_width, y
+        return x, y
 
     def port_scene_position(self, port_type: PortType, index: int,
                             t: QTransform = None) -> QPointF:

--- a/qtpynodeeditor/node_painter.py
+++ b/qtpynodeeditor/node_painter.py
@@ -55,6 +55,7 @@ class NodePainter:
             return
 
         geom.recalculate_size(painter.font())
+        node.graphics_object.move_connections()
 
         model = node.model
         NodePainter.draw_node_rect(painter, geom, model, graphics_object,
@@ -131,13 +132,13 @@ class NodePainter:
         """
         if not model.caption_visible:
             return
-        name = model.caption
+        name = model.caption or ""
         f = painter.font()
         f.setBold(True)
         metrics = QFontMetrics(f)
         rect = metrics.boundingRect(name)
         if node_style.layout_direction is LayoutDirection.VERTICAL:
-            extra_vert_pad = rect.height() * 2
+            extra_vert_pad = rect.height() * 2  # leave space for port names
         else:
             extra_vert_pad = 0
         position = QPointF((geom.width - rect.width()) / 2.0,

--- a/qtpynodeeditor/node_painter.py
+++ b/qtpynodeeditor/node_painter.py
@@ -9,7 +9,7 @@ from .node_data import NodeDataModel
 from .node_geometry import NodeGeometry
 from .node_graphics_object import NodeGraphicsObject
 from .node_state import NodeState
-from .style import ConnectionStyle, NodeStyle
+from .style import ConnectionStyle, LayoutDirection, NodeStyle
 
 if typing.TYPE_CHECKING:
     from .connection import Connection  # noqa
@@ -136,8 +136,12 @@ class NodePainter:
         f.setBold(True)
         metrics = QFontMetrics(f)
         rect = metrics.boundingRect(name)
+        if node_style.layout_direction is LayoutDirection.VERTICAL:
+            extra_vert_pad = rect.height() * 2
+        else:
+            extra_vert_pad = 0
         position = QPointF((geom.width - rect.width()) / 2.0,
-                           (geom.spacing + geom.entry_height) / 3.0)
+                           (geom.spacing + geom.entry_height + extra_vert_pad) / 3.0)
         painter.setFont(f)
         painter.setPen(node_style.font_color)
         painter.drawText(position, name)
@@ -170,12 +174,21 @@ class NodePainter:
 
             display_text = port.display_text
             rect = metrics.boundingRect(display_text)
-            scene_pos.setY(scene_pos.y() + rect.height() / 4.0)
-            if port.port_type == PortType.input:
-                scene_pos.setX(5.0)
-            elif port.port_type == PortType.output:
-                scene_pos.setX(geom.width - 5.0 - rect.width())
+            if node_style.layout_direction == LayoutDirection.HORIZONTAL:
+                scene_pos.setY(scene_pos.y() + rect.height() / 4.0)
+            elif node_style.layout_direction == LayoutDirection.VERTICAL:
+                if port.port_type == PortType.input:
+                    scene_pos.setY(scene_pos.y() + rect.height())
+                elif port.port_type == PortType.output:
+                    scene_pos.setY(scene_pos.y() - rect.height())
 
+            if node_style.layout_direction == LayoutDirection.HORIZONTAL:
+                if port.port_type == PortType.input:
+                    scene_pos.setX(5.0)
+                elif port.port_type == PortType.output:
+                    scene_pos.setX(geom.width - 5.0 - rect.width())
+            elif node_style.layout_direction is LayoutDirection.VERTICAL:
+                scene_pos.setX(scene_pos.x() - rect.width() / 2)
             painter.drawText(scene_pos, display_text)
 
     @staticmethod

--- a/qtpynodeeditor/node_state.py
+++ b/qtpynodeeditor/node_state.py
@@ -50,7 +50,9 @@ class NodeState:
                 # (may break incoming connections)
                 for i in range(num_ports):
                     if i not in self._ports[port_type]:
-                        self._ports[port_type][i] = Port(self.node, port_type=port_type, index=i)
+                        self._ports[port_type][i] = Port(self.node,
+                                                         port_type=port_type,
+                                                         index=i)
                 continue
 
             # otherwise we may need to shift existing connections
@@ -63,10 +65,10 @@ class NodeState:
                 for conn in port.connections:
                     old_connections[port_idx].append(conn)
 
-            if len(old_connections) > num_ports - 1:
+            if len(old_connections) > num_ports:
                 raise RuntimeError(
                     "Gathered too many ports to reconnect "
-                    f"({len(old_connections)} into {num_ports - 1} ports)"
+                    f"({len(old_connections)} into {num_ports} ports)"
                 )
 
             # Create new ports to set up new indexing

--- a/qtpynodeeditor/style.py
+++ b/qtpynodeeditor/style.py
@@ -1,7 +1,7 @@
-from enum import StrEnum, auto
 import json
 import logging
 import random
+from enum import StrEnum, auto
 
 from qtpy.QtGui import QColor
 
@@ -255,7 +255,7 @@ class NodeStyle(Style):
         self.connection_point_diameter = float(
             style['ConnectionPointDiameter'])
         self.opacity = float(style['Opacity'])
-        self.layout_direction = LayoutDirection[style["LayoutDirection"]]
+        self.layout_direction = LayoutDirection[style.get("LayoutDirection", "HORIZONTAL")]
 
 
 class StyleCollection:

--- a/qtpynodeeditor/style.py
+++ b/qtpynodeeditor/style.py
@@ -35,6 +35,11 @@ class LayoutDirection(StrEnum):
         return None
 
 
+class SplineType(StrEnum):
+    CUBIC = auto()
+    LINEAR = auto()
+
+
 class Style:
     default_style = {
         "FlowViewStyle": {
@@ -75,7 +80,8 @@ class Style:
             "LineWidth": 3.0,
             "ConstructionLineWidth": 2.0,
             "PointDiameter": 10.0,
-            "UseDataDefinedColors": False
+            "UseDataDefinedColors": False,
+            "SplineType": "CUBIC"
         }
     }
 
@@ -136,6 +142,7 @@ class ConnectionStyle(Style):
     construction_line_width : float
     point_diameter : float
     use_data_defined_colors : bool
+    spline_type : SplineType
     '''
 
     def __init__(self, json_style=None):
@@ -151,6 +158,7 @@ class ConnectionStyle(Style):
 
         self.use_data_defined_colors = True
 
+        self.spline_type = SplineType.CUBIC
         super().__init__(json_style=json_style)
 
     def load_from_json(self, json_style: str):
@@ -173,6 +181,8 @@ class ConnectionStyle(Style):
         self.construction_line_width = float(style['ConstructionLineWidth'])
         self.point_diameter = float(style['PointDiameter'])
         self.use_data_defined_colors = bool(style['UseDataDefinedColors'])
+
+        self.spline_type = SplineType[style.get("SplineType", "CUBIC")]
 
     def get_normal_color(self, type_id: str = None) -> QColor:
         """

--- a/qtpynodeeditor/style.py
+++ b/qtpynodeeditor/style.py
@@ -1,3 +1,4 @@
+from enum import StrEnum, auto
 import json
 import logging
 import random
@@ -19,6 +20,19 @@ def _get_qcolor(style_dict, key):
     logger.debug('Loaded color %s = %s -> %d %d %d %d', key, name_or_list,
                  *color.getRgb())
     return color
+
+
+class LayoutDirection(StrEnum):
+    HORIZONTAL = auto()
+    VERTICAL = auto()
+
+    @classmethod
+    def _missing_(cls, value: str):
+        value = value.lower()
+        for member in cls:
+            if member.value == value:
+                return member
+        return None
 
 
 class Style:
@@ -48,7 +62,9 @@ class Style:
 
             "ConnectionPointDiameter": 8.0,
 
-            "Opacity": 0.8
+            "Opacity": 0.8,
+
+            "LayoutDirection": "HORIZONTAL"
         },
         "ConnectionStyle": {
             "ConstructionColor": "gray",
@@ -200,6 +216,8 @@ class NodeStyle(Style):
         self.connection_point_diameter = 5.0
         self.opacity = 1.0
 
+        self.layout_direction = LayoutDirection.HORIZONTAL
+
         super().__init__(json_style=json_style)
 
     def load_from_json(self, json_style: str):
@@ -237,6 +255,7 @@ class NodeStyle(Style):
         self.connection_point_diameter = float(
             style['ConnectionPointDiameter'])
         self.opacity = float(style['Opacity'])
+        self.layout_direction = LayoutDirection[style["LayoutDirection"]]
 
 
 class StyleCollection:


### PR DESCRIPTION
## Description
- Enables a vertical layout of nodes, with inputs on the top and outputs on the bottom
- Enables dynamic node numbers by updating NodeState's ports and connections based on the model's num_ports 
- Re-order port order in Connection to create a properly directed graph

To-Do: 
- [x] Adjust spline types to be more sensible in vertical mode.  Possibly add a variety of options
- [ ] Look into ways of coloring nodes dynamically
- [x] Add an example showing this new behavior


## Motivation and Context
For Behavior Trees / BEAMS, we're looking to build and represent tree structures.  This package seemed like a good starting point, so I've forked it and will be contributing to the pcdshub fork.  

I spent a good amount of time trying to keep to the "public" methods, but ended up just going through some of the single underscore private attributes.  There was also a good amount of iteration trying to find the right way to disconnect connections.  Turns out we're very thorough about deleting references if we use public methods, and if we want to reassign connections we need to do it mostly manually.

At some point we should consider upstreaming this to the klauer branch, but in the short term we want to move a little faster.

## How Has This Been Tested?
interactively

try: `python -m qtpynodeeditor.examples.tree`

## Where Has This Been Documented?
This PR.

<img width="466" alt="image" src="https://github.com/user-attachments/assets/2e1a4ef4-213b-43ef-812a-b581814526d3" />
