### PR TITLE
BUG: catch non-unique connection attempts and continue.  Permits edge reconnection attempts

### DIFF
--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 
 from qtpy.QtCore import QDir, QPoint, QPointF, Qt, Signal
@@ -18,6 +19,8 @@ from .node_data import NodeDataModel, NodeDataType
 from .node_graphics_object import NodeGraphicsObject
 from .port import Port, PortType
 from .type_converter import TypeConverter
+
+logger = logging.getLogger(__name__)
 
 
 def locate_node_at(scene_point, scene, view_transform):
@@ -202,8 +205,11 @@ class FlowSceneModel:
         ----------
         conn : Connection
         """
-        conn.connection_made_incomplete.connect(
-            self._connection_made_incomplete, Qt.UniqueConnection)
+        try:
+            conn.connection_made_incomplete.connect(
+                self._connection_made_incomplete, Qt.UniqueConnection)
+        except TypeError:
+            logger.debug("Duplicate connection attempted, ignoring...")
 
     def _send_connection_created_to_nodes(self, conn: Connection):
         """


### PR DESCRIPTION
## Description
- Wraps the connection_made_incomplete signal connection attempt in a try-except so the app doesn't implode if we try to make a duplicate connection

## Motivation and Context
We want to be able to move connections around.  This was uncovered by Zach in #1, where an exception would be thrown if you drag a connection from one node to another.

https://github.com/pcdshub/qtpynodeeditor/pull/1#discussion_r2178212181

## Why can we ignore the second attempt at this?  
This is a setup method that is called when a connection is first created, holding slots that fire when a connection is made incomplete.  In the case where we're moving a connection around, this signal has already been connected and all is well.

In this case we don't need to re-connect that signal, since its function isn't dependent on the ports the connection is connecting.  This callback only emits another signal, while passing the connection through the entire time.  I assume downstream consumers inspect that connection to determine what to do.

## How Has This Been Tested?
I ran the calculator example and tried moving connections around.  The debug statements print, but data flows through the nodes as expected.  

## Where Has This Been Documented?
This PR