### PR TITLE
MNT: some small bugfixes for older python versions and CI/type hints

### DIFF
--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -618,13 +618,13 @@ class FlowScene(FlowSceneModel, QGraphicsScene):
         # create_connection(...)
         return connection
 
-    def create_node(self, data_model: NodeDataModel) -> Node:
+    def create_node(self, data_model: type[NodeDataModel]) -> Node:
         """
         Create a node in the scene
 
         Parameters
         ----------
-        data_model : NodeDataModel
+        data_model : a subclass of NodeDataModel
 
         Returns
         -------

--- a/qtpynodeeditor/node_graphics_object.py
+++ b/qtpynodeeditor/node_graphics_object.py
@@ -91,6 +91,9 @@ class NodeGraphicsObject(QGraphicsObject):
         Visits all attached connections and corrects their corresponding end points.
         """
         for conn in self._node.state.all_connections:
+            if conn.graphics_object is None:
+                # CI might not have this graphics object
+                continue
             conn.graphics_object.move()
 
     def lock(self, locked: bool):

--- a/qtpynodeeditor/style.py
+++ b/qtpynodeeditor/style.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import random
-from enum import StrEnum, auto
+from enum import Enum
 
 from qtpy.QtGui import QColor
 
@@ -22,9 +22,9 @@ def _get_qcolor(style_dict, key):
     return color
 
 
-class LayoutDirection(StrEnum):
-    HORIZONTAL = auto()
-    VERTICAL = auto()
+class LayoutDirection(Enum):
+    HORIZONTAL = "HORIZONTAL"
+    VERTICAL = "VERTICAL"
 
     @classmethod
     def _missing_(cls, value: str):
@@ -35,9 +35,9 @@ class LayoutDirection(StrEnum):
         return None
 
 
-class SplineType(StrEnum):
-    CUBIC = auto()
-    LINEAR = auto()
+class SplineType(Enum):
+    CUBIC = "CUBIC"
+    LINEAR = "LINEAR"
 
 
 class Style:


### PR DESCRIPTION
## Description
- Drops reliance on `StrEnum` to allow compliance with older versions of python (< 3.11)
- Adjusts a type hint
- Adds a none-check that fails in local pytest runs

## Motivation and Context
The StrEnum is breaking downstream BEAMS CI, and this package was originally being tested on 3.9-3.12.  I do want to eventually upstream this, so I'll do my best to keep the same compatibility as it came with

The other changes aren't huge, but while I was here I might as well get them in.

## How Has This Been Tested?
CI locally, we still haven't set up CI for our fork here

## Where Has This Been Documented?
This PR.