### PR TITLE
CI/AUTO: SHA Pinning and Dependabot

### DIFF
--- a/.github/dependabot_template.yml
+++ b/.github/dependabot_template.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+      exclude:
+      - pcdshub/pcds-ci-helpers/*

--- a/.github/workflows/pcds.yml
+++ b/.github/workflows/pcds.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit checks"
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/pre-commit.yml@master
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/pre-commit.yml@2e7e5ec8fb8afca5fa0cdb60b82b0f1b99cd2647
     with:
       args: "--all-files"
 
@@ -26,7 +26,7 @@ jobs:
           - python-version: "3.12"
 
     name: "Conda"
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-conda-test.yml@master
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-conda-test.yml@2e7e5ec8fb8afca5fa0cdb60b82b0f1b99cd2647
     secrets: inherit
     with:
       package-name: "qtpynodeeditor"
@@ -110,7 +110,7 @@ jobs:
   #
   # pip-docs:
   #   name: "Documentation"
-  #   uses: pcdshub/pcds-ci-helpers/.github/workflows/python-docs.yml@master
+  #   uses: pcdshub/pcds-ci-helpers/.github/workflows/python-docs.yml@2e7e5ec8fb8afca5fa0cdb60b82b0f1b99cd2647
   #   with:
   #     package-name: "qtpynodeeditor"
   #     python-version: "3.9"

--- a/.github/workflows/python-pip-test.yml
+++ b/.github/workflows/python-pip-test.yml
@@ -68,7 +68,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           submodules: "recursive"
@@ -97,7 +97,7 @@ jobs:
         run: |
           mkdir $HOME/logs
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "${{ inputs.python-version }}"
 
@@ -208,14 +208,14 @@ jobs:
 
       # - name: Upload log file artifacts
       #   if: ${{ always() }}
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       #   with:
       #     name: Python ${{ inputs.python-version }} - ${{ inputs.artifact-name }} - testing log
       #     path: "~/logs"
 
       - name: Upload the package as an artifact
         if: ${{ inputs.upload-artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: Python ${{ inputs.python-version }} - ${{ inputs.artifact-name }} - package
           path: dist


### PR DESCRIPTION

# SHA Pinning

We are now required to pin GitHub Actions to specific SHAs.
This PR automatically updates all actions to a somewhat recent SHA.
It also configures dependabot to update the SHAs for us on a monthly basis.

If this PR is not merged, all GitHub Actions Workflows in this repository
will stop working at the end of June 2026.

See https://jira.slac.stanford.edu/browse/ECS-10557

## Code Review

For reviewers: our task is to pick one of:

- Merge as-is, then fix the CI if needed
- Fix the CI, and then merge
- Close this PR and archive the repo
- Merge this PR and archive the repo
- Remove the GitHub Actions configuration from the repo,
  then close this PR.
- Ignore this PR until we use the repo again
